### PR TITLE
Fix issue where cratePath was used instead of crateName

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -125,7 +125,7 @@ function vitePluginWasmPack(
         }
         // replace default load path with '/assets/xxx.wasm'
         const jsName = crateName.replace(/\-/g, '_') + '.js';
-        const jsPath = path.join('./node_modules', cratePath, jsName);
+        const jsPath = path.join('./node_modules', crateName, jsName);
         const regex = /input = new URL\('(.+)'.+;/g;
         let code = fs.readFileSync(path.resolve(jsPath), { encoding: 'utf-8' });
         code = code.replace(regex, (_match, group1) => {


### PR DESCRIPTION
When trying to use a crate path that was not a sibling directory like the example (i.e., `../my-crate` instead of `./my-crate`) there is a bug when copying to the `node_modules` folder. This update uses the correct string to form the path.