### PR TITLE
Use require.resolve for modules

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -133,7 +133,7 @@ function vitePluginWasmPack(
          * crateName === 'test'
          */
 
-        let jsPath = path.join('./node_modules', isNodeModule ? cratePath : crateName, jsName);
+        let jsPath = path.join('./node_modules', crateName, jsName);
         if (isNodeModule) {
           jsPath = path.join(pkgPath, jsName);
         }


### PR DESCRIPTION
Instead of hard coding the `pkg` path for the `moduleCrates` this plugin should use `require.resolve` to get the location of the wasm-pack bundle files. This is useful for projects that have a static `package.json` at the root of the crate the defines its entry point with `main`. It allows for the wasm-pack bundle to live in any directory in the module (i.e `dist`, `lib`, `pkg`, etc.) as well.

I ran into this issue in my project which is lain out like so:
```
├── README.md
├── package.json
├── packages
│   ├── web
│   └── webgl
│       ├── Cargo.lock
│       ├── Cargo.toml
│       ├── README.md
│       ├── package.json
│       ├── pkg
│       │   ├── webgl.d.ts
│       │   ├── webgl.js
│       │   ├── webgl_bg.d.ts
│       │   └── webgl_bg.wasm
│       └── src
├── pnpm-lock.yaml
└── pnpm-workspace.yaml
```
