### PR TITLE
remove wrapping arrow func to handle all requests in middleware

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -159,25 +159,23 @@ function vitePluginWasmPack(
     },
 
     configureServer({ middlewares }) {
-      return () => {
-        // send 'root/pkg/xxx.wasm' file to user
-        middlewares.use((req, res, next) => {
-          if (isString(req.url)) {
-            const basename = path.basename(req.url);
-            res.setHeader(
-              'Cache-Control',
-              'no-cache, no-store, must-revalidate'
-            );
-            const entry = wasmMap.get(basename);
-            if (basename.endsWith('.wasm') && entry) {
-              res.writeHead(200, { 'Content-Type': 'application/wasm' });
-              fs.createReadStream(entry.path).pipe(res);
-            } else {
-              next();
-            }
+      // send 'root/pkg/xxx.wasm' file to user
+      middlewares.use((req, res, next) => {
+        if (isString(req.url)) {
+          const basename = path.basename(req.url);
+          res.setHeader(
+            'Cache-Control',
+            'no-cache, no-store, must-revalidate'
+          );
+          const entry = wasmMap.get(basename);
+          if (basename.endsWith('.wasm') && entry) {
+            res.writeHead(200, { 'Content-Type': 'application/wasm' });
+            fs.createReadStream(entry.path).pipe(res);
+          } else {
+            next();
           }
-        });
-      };
+        }
+      });
     },
 
     buildEnd() {


### PR DESCRIPTION
on vite 5.2+, the middleware in this plugin which filters for request urls ending in `.wasm` is not handling all requests. after some fiddling I found removing this wrapping arrow func seems to fix it.

I think this is a problem on the later vite dev servers only