### PR TITLE
use originalUrl to detect request for a wasm file

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -161,8 +161,9 @@ function vitePluginWasmPack(
     configureServer({ middlewares }) {
       // send 'root/pkg/xxx.wasm' file to user
       middlewares.use((req, res, next) => {
-        if (isString(req.url)) {
-          const basename = path.basename(req.url);
+        const incomingUrl = req.originalUrl ?? req.url;
+        if (isString(incomingUrl)) {
+          const basename = path.basename(incomingUrl);
           res.setHeader(
             'Cache-Control',
             'no-cache, no-store, must-revalidate'


### PR DESCRIPTION
In the newest vite (tested on 5.3.4) the `req.url` is changed by `htmlFallbackMiddleware` to `/index.html` if there is no available resource (ie. in `/public` directory) under the requested url. It stores the original browser's path in `req.originalUrl`.

I fixed it because I'm starting to learn about using Rust in the webassembly and I like this plugin :)  